### PR TITLE
Improve Output Folder Structure with Unique Run IDs

### DIFF
--- a/SimpleAgent/SimpleAgent.py
+++ b/SimpleAgent/SimpleAgent.py
@@ -25,6 +25,7 @@ from commands import REGISTERED_COMMANDS, COMMAND_SCHEMAS
 # Import core modules
 from core.agent import SimpleAgent
 from core.config import OPENAI_API_KEY, MAX_STEPS
+from core.version import AGENT_VERSION
 
 # Initialize commands
 commands.init()
@@ -59,8 +60,9 @@ def main():
     base_output_dir = os.path.abspath('output')
     if not os.path.exists(base_output_dir):
         os.makedirs(base_output_dir)
-    run_id = str(uuid.uuid4())
-    run_output_dir = os.path.join(base_output_dir, f"run_{run_id}")
+    run_id = str(uuid.uuid4())[:8]
+    version_folder = 'v' + '_'.join(AGENT_VERSION.lstrip('v').split('.'))
+    run_output_dir = os.path.join(base_output_dir, f"{version_folder}_{run_id}")
     os.makedirs(run_output_dir)
 
     # Initialize and run the agent with the unique output directory

--- a/SimpleAgent/SimpleAgent.py
+++ b/SimpleAgent/SimpleAgent.py
@@ -63,7 +63,7 @@ def main():
     run_id = str(uuid.uuid4())[:8]
     version_folder = 'v' + '_'.join(AGENT_VERSION.lstrip('v').split('.'))
     run_output_dir = os.path.join(base_output_dir, f"{version_folder}_{run_id}")
-    os.makedirs(run_output_dir)
+    os.makedirs(run_output_dir, exist_ok=True)
 
     # Initialize and run the agent with the unique output directory
     agent = SimpleAgent(output_dir=run_output_dir)

--- a/SimpleAgent/SimpleAgent.py
+++ b/SimpleAgent/SimpleAgent.py
@@ -12,6 +12,7 @@ import json
 import time
 import argparse
 import logging
+import uuid
 from typing import List, Dict, Any, Optional, Callable
 
 # Set up basic logging configuration
@@ -53,9 +54,17 @@ def main():
     
     # Ensure max_steps is at least as large as auto_continue
     max_steps = max(args.max_steps, args.auto) if args.auto > 0 else args.max_steps
-    
-    # Initialize and run the agent
-    agent = SimpleAgent()
+
+    # Create a unique output directory for this run
+    base_output_dir = os.path.abspath('output')
+    if not os.path.exists(base_output_dir):
+        os.makedirs(base_output_dir)
+    run_id = str(uuid.uuid4())
+    run_output_dir = os.path.join(base_output_dir, f"run_{run_id}")
+    os.makedirs(run_output_dir)
+
+    # Initialize and run the agent with the unique output directory
+    agent = SimpleAgent(output_dir=run_output_dir)
     agent.run(instruction, max_steps=max_steps, auto_continue=args.auto)
 
 

--- a/SimpleAgent/core/version.py
+++ b/SimpleAgent/core/version.py
@@ -1,0 +1,1 @@
+AGENT_VERSION = 'v0.4.0'


### PR DESCRIPTION
Fixes #15

Currently, when the agent starts, it creates an output folder inside the existing output directory and stores all generated files there. This approach can lead to clutter and potential conflicts between files from different runs.  Instead, the agent should create a new subfolder with a unique ID for each run and store that run's files inside it. This will improve organization, prevent interference between runs, and make output management easier.
GitHub